### PR TITLE
Feat/revert to selection based

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A userscript designed to assist users reading Latin text on Vicipaedia (the Lati
 
 ## Description
 
-This script monitors mouse movements over text content on `https://la.wikipedia.org/*`. When the cursor hovers over a potential Latin word for a brief period, the script automatically queries the `latin-words.com` service for its definition and grammatical information. The results are then displayed in a convenient tooltip near the cursor.
+This script monitors text selections on `https://la.wikipedia.org/*`. When the user selects text containing a Latin word, the script automatically queries the `latin-words.com` service for its definition and grammatical information. The results are then displayed in a convenient tooltip near the selection.
 
 ## Features
 
-* **On-Hover Lookup:** Automatically detects Latin words under the cursor.
+* **On-Selection Lookup:** Automatically detects Latin words from user text selections.
 * **Tooltip Display:** Shows definitions and grammatical analysis in a floating tooltip.
 * **Data Source:** Utilizes the `latin-words.com` website via its translation endpoint.
 * **Parsing:** Interprets the response from `latin-words.com` to extract dictionary entries (lemma, part of speech, definitions) and grammatical forms of the queried word.
@@ -35,22 +35,20 @@ This script is specifically configured to run on:
 
 1.  **Navigate:** Go to any page on `https://la.wikipedia.org/`.
 2.  **Ensure Enabled:** Check that the floating 'L' button (usually in the bottom-right corner) is blue, indicating the script is active. Click it to toggle between enabled (blue) and disabled (grey) states.
-3.  **Hover:** Move your mouse cursor over any Latin word within the main text content.
-4.  **View Tooltip:** After a short delay (approx. 350ms), a tooltip should appear near the word, displaying its definition and grammatical details fetched from `latin-words.com`.
-5.  **Hide Tooltip:** Move the cursor away from the word, scroll the page, or click the toggle button to disable lookups. The tooltip will disappear automatically.
+3.  **Select Text:** Highlight any Latin word or text containing Latin words within the main content.
+4.  **View Tooltip:** A tooltip will appear near the selection, displaying the definition and grammatical details of the first Latin word found in your selection, fetched from `latin-words.com`.
+5.  **Hide Tooltip:** Click elsewhere on the page or make a new selection. The tooltip will disappear automatically.
 
 ## How It Works
 
-* The script listens for `mousemove` events.
-* It attempts to identify the word directly under the cursor using `document.caretPositionFromPoint` or `document.caretRangeFromPoint`.
+* The script listens for text selection events (`mouseup`, `keyup`).
+* When text is selected, it extracts the first valid Latin word from the selection.
 * It validates if the identified text is likely a Latin word (alphabetic characters, including macrons, minimum length 2).
-* A timer prevents lookups on rapid mouse movements.
-* If the same word remains under the cursor for the duration of the `hoverDelay`, the script proceeds.
 * Macrons are stripped from the word before checking the cache or making an API request.
 * If not cached, it makes a `GM_xmlhttpRequest` to the `latin-words.com` endpoint.
 * The JSON response is parsed to extract grammatical forms, dictionary entries, and definitions.
 * This parsed information is formatted into HTML.
-* The HTML content is displayed in the tooltip element, positioned near the cursor while avoiding screen edges.
+* The HTML content is displayed in the tooltip element, positioned near the selection while avoiding screen edges.
 
 ## Dependencies
 
@@ -60,6 +58,6 @@ This script is specifically configured to run on:
 ## Limitations & Considerations
 
 * The accuracy of definitions and parsing depends entirely on the data provided by `latin-words.com` and the script's ability to interpret its specific format.
-* The word detection mechanism might occasionally fail on complex page layouts or specific HTML structures.
+* The selection-based lookup works best with single words or short phrases. For multi-word selections, only the first valid Latin word will be looked up.
 * Performance may vary depending on the complexity of the page and the browser.
 * Works only on the specified `@match` domain (`la.wikipedia.org`).

--- a/auto-lookup-latin-word.user.js
+++ b/auto-lookup-latin-word.user.js
@@ -482,7 +482,6 @@
     // Word Lookup Handler (REVISED for selection-based lookup)
     // ====================================
     const WordLookup = {
-        lastSelectedWord: '',
         cache: {},
 
         /**
@@ -550,9 +549,7 @@
             // Extract a single Latin word from the selection
             const word = this.extractLatinWord(selectedText);
             
-            if (word && word !== this.lastSelectedWord) {
-                this.lastSelectedWord = word;
-                
+            if (word) {
                 // Get position for tooltip
                 const range = selection.getRangeAt(0);
                 const rect = range.getBoundingClientRect();
@@ -564,9 +561,8 @@
                 const clientY = rect.bottom;
                 
                 this.lookupWord(word, pageX, pageY, clientX, clientY);
-            } else if (!word) {
+            } else {
                 UI.hideTooltip();
-                this.lastSelectedWord = '';
             }
         },
 
@@ -647,19 +643,13 @@
 
             LatinAPI.lookupWord(lookupWord)
                 .then(response => {
-                    if (originalWord === this.lastSelectedWord) {
-                        const parsedData = ResponseParser.parse(response);
-                        this.cache[lookupWord] = parsedData;
-                        UI.showTooltip(pageX, pageY, clientX, clientY, UI.formatWordInfo(parsedData));
-                    } else {
-                        Logger.debug(`Selected word changed before API response for "${lookupWord}" arrived.`);
-                    }
+                    const parsedData = ResponseParser.parse(response);
+                    this.cache[lookupWord] = parsedData;
+                    UI.showTooltip(pageX, pageY, clientX, clientY, UI.formatWordInfo(parsedData));
                 })
                 .catch(error => {
                     Logger.error(`Failed to lookup word "${lookupWord}": ${error}`);
-                    if (originalWord === this.lastSelectedWord) {
-                        UI.showTooltip(pageX, pageY, clientX, clientY, '<div class="latin-lookup-error">Failed to lookup word</div>');
-                    }
+                    UI.showTooltip(pageX, pageY, clientX, clientY, '<div class="latin-lookup-error">Failed to lookup word</div>');
                 });
         }
     };

--- a/auto-lookup-latin-word.user.js
+++ b/auto-lookup-latin-word.user.js
@@ -2,7 +2,7 @@
 // @name         Auto Lookup Latin Word
 // @namespace    https://github.com/InvictusNavarchus
 // @version      0.3.1
-// @description  Automatically lookup Latin words on hover and display their meanings
+// @description  Automatically lookup Latin words on text selection and display their meanings
 // @author       Invictus
 // @match        https://la.wikipedia.org/*
 // @connect      latin-words.com
@@ -19,7 +19,7 @@
     // Script Configuration
     // ====================================
     const config = {
-        hoverDelay: 350, // Delay in milliseconds before showing tooltip
+        // No longer need hover delay for selection-based lookup
     }
     
     // ====================================
@@ -330,7 +330,7 @@
             const button = document.createElement('div');
             button.id = 'latin-lookup-toggle';
             button.textContent = 'L';
-            button.title = 'Toggle Latin word lookup';
+            button.title = 'Toggle Latin word lookup on selection';
             button.className = 'latin-lookup-enabled';
 
             button.addEventListener('click', () => {
@@ -479,192 +479,154 @@
 
 
     // ====================================
-    // Word Lookup Handler (Keep as is)
+    // Word Lookup Handler (REVISED for selection-based lookup)
     // ====================================
     const WordLookup = {
-        hoverDelay: config.hoverDelay,
-        hoverTimer: null,
-        lastWord: '',
+        lastSelectedWord: '',
         cache: {},
 
+        /**
+         * Initialize the selection-based word lookup system
+         */
         init: function () {
             this.setupEventListeners();
-            Logger.info("Word lookup handler initialized");
+            Logger.info("Selection-based word lookup handler initialized");
         },
 
+        /**
+         * Set up event listeners for text selection
+         */
         setupEventListeners: function () {
-            document.addEventListener('mousemove', this.handleMouseMove.bind(this));
-            document.body.addEventListener('mouseleave', () => {
-                UI.hideTooltip();
-                this.clearHoverTimer();
-                this.lastWord = '';
+            document.addEventListener('mouseup', this.handleTextSelection.bind(this));
+            document.addEventListener('keyup', this.handleTextSelection.bind(this));
+            document.addEventListener('selectionchange', this.handleSelectionChange.bind(this));
+            
+            // Hide tooltip when clicking elsewhere
+            document.addEventListener('click', (event) => {
+                if (!event.target.closest('#latin-lookup-tooltip') && 
+                    !event.target.closest('#latin-lookup-toggle')) {
+                    const selection = window.getSelection();
+                    if (selection.rangeCount === 0 || selection.toString().trim() === '') {
+                        UI.hideTooltip();
+                    }
+                }
             });
-            document.addEventListener('scroll', () => {
-                UI.hideTooltip();
-                this.clearHoverTimer();
-            }, true);
         },
 
-        handleMouseMove: function (event) {
+        /**
+         * Handle text selection events (mouseup, keyup)
+         */
+        handleTextSelection: function (event) {
             if (!UI.enabled) return;
 
-            const target = event.target;
-
-            if (target.id === 'latin-lookup-tooltip' || target.id === 'latin-lookup-toggle' ||
-                target.closest('#latin-lookup-tooltip') || target.closest('#latin-lookup-toggle')) {
+            // Ignore events on our UI elements
+            if (event.target.closest('#latin-lookup-tooltip') || 
+                event.target.closest('#latin-lookup-toggle')) {
                 return;
             }
 
-            const elementUnderCursor = document.elementFromPoint(event.clientX, event.clientY);
-            if (elementUnderCursor && (this.isTextNode(elementUnderCursor) || this.hasTextChild(elementUnderCursor) || (elementUnderCursor.nodeType === Node.ELEMENT_NODE && elementUnderCursor.textContent.trim().length > 0))) {
-                const word = this.getWordAtPoint(event.clientX, event.clientY);
+            setTimeout(() => {
+                this.processSelection(event);
+            }, 10); // Small delay to ensure selection is finalized
+        },
 
-                if (word && word.length > 1 && this.isLatinWord(word)) {
-                    if (word !== this.lastWord) {
-                        this.lastWord = word;
-                        this.clearHoverTimer();
+        /**
+         * Handle selection change events
+         */
+        handleSelectionChange: function () {
+            if (!UI.enabled) return;
+            
+            setTimeout(() => {
+                this.processSelection();
+            }, 10); // Small delay to ensure selection is finalized
+        },
 
-                        this.hoverTimer = setTimeout(() => {
-                            this.lookupWord(word, event.pageX, event.pageY, event.clientX, event.clientY);
-                        }, this.hoverDelay);
-                    }
-                } else {
-                    UI.hideTooltip();
-                    this.clearHoverTimer();
-                    this.lastWord = '';
-                }
-            } else {
+        /**
+         * Process the current text selection
+         */
+        processSelection: function (event = null) {
+            const selection = window.getSelection();
+            
+            if (selection.rangeCount === 0) {
                 UI.hideTooltip();
-                this.clearHoverTimer();
-                this.lastWord = '';
+                return;
+            }
+
+            const selectedText = selection.toString().trim();
+            
+            if (!selectedText) {
+                UI.hideTooltip();
+                return;
+            }
+
+            // Extract a single Latin word from the selection
+            const word = this.extractLatinWord(selectedText);
+            
+            if (word && word !== this.lastSelectedWord) {
+                this.lastSelectedWord = word;
+                
+                // Get position for tooltip
+                const range = selection.getRangeAt(0);
+                const rect = range.getBoundingClientRect();
+                
+                // Calculate page coordinates from client coordinates
+                const pageX = rect.left + window.scrollX;
+                const pageY = rect.bottom + window.scrollY;
+                const clientX = rect.left;
+                const clientY = rect.bottom;
+                
+                this.lookupWord(word, pageX, pageY, clientX, clientY);
+            } else if (!word) {
+                UI.hideTooltip();
+                this.lastSelectedWord = '';
             }
         },
 
-        getWordAtPoint: function (x, y) {
-            try {
-                const element = document.elementFromPoint(x, y);
-                if (!element) return null;
-
-                let range, textNode, offset;
-
-                if (document.caretPositionFromPoint) {
-                    const position = document.caretPositionFromPoint(x, y);
-                    if (position) {
-                        textNode = position.offsetNode;
-                        offset = position.offset;
-                    }
-                }
-                else if (document.caretRangeFromPoint) {
-                    range = document.caretRangeFromPoint(x, y);
-                    if (range) {
-                        textNode = range.startContainer;
-                        offset = range.startOffset;
-                    }
-                }
-
-                if (!textNode || textNode.nodeType !== Node.TEXT_NODE) {
-                    // Try to find the first text node child if element itself isn't one
-                    let foundTextNode = false;
-                    if (element.childNodes.length > 0) {
-                        for (let i = 0; i < element.childNodes.length; i++) {
-                            if (element.childNodes[i].nodeType === Node.TEXT_NODE && element.childNodes[i].textContent.trim().length > 0) {
-                                textNode = element.childNodes[i];
-                                offset = Math.floor(textNode.textContent.length / 2); // Estimate middle
-                                foundTextNode = true;
-                                break;
-                            }
-                        }
-                    }
-                    if (!foundTextNode) return null; // Give up if no suitable text node found
-
-                    // Original Fallback (might be less reliable than above)
-                    // if (element.textContent && element.childNodes.length === 1 && element.childNodes[0].nodeType === Node.TEXT_NODE) {
-                    //     textNode = element.childNodes[0];
-                    //     offset = Math.floor(textNode.textContent.length / 2);
-                    // } else {
-                    //     return null;
-                    // }
-                }
-
-
-                const text = textNode.textContent;
-
-                if (offset < 0 || offset > text.length) {
-                    offset = Math.floor(text.length / 2);
-                }
-
-                let startPos = this.findWordStart(text, offset);
-                let endPos = this.findWordEnd(text, offset);
-
-                const word = text.substring(startPos, endPos).trim();
-
-                if (word.length > 0 && word.length < 50) {
-                    // Normalize: Remove trailing punctuation common in text
-                    return word.replace(/[.,;:!?)"\]]*$/, '');
-                } else {
-                    return null;
-                }
-
-            } catch (e) {
-                Logger.error(`Error getting word at point: ${e}`);
-                return null;
+        /**
+         * Extract a single Latin word from selected text
+         */
+        extractLatinWord: function (selectedText) {
+            // Remove extra whitespace and normalize
+            const cleanText = selectedText.replace(/\s+/g, ' ').trim();
+            
+            // If it's a single word, check if it's Latin
+            const words = cleanText.split(/\s+/);
+            
+            if (words.length === 1) {
+                const word = this.normalizeWord(words[0]);
+                return this.isLatinWord(word) ? word : null;
             }
-        },
-
-        findWordStart: function (text, offset) {
-            if (offset > 0 && !this.isWordChar(text.charAt(offset - 1)) && this.isWordChar(text.charAt(offset))) {
-                // Start is good
-            } else {
-                offset = Math.max(0, offset - 1);
-            }
-
-            let pos = offset;
-            while (pos >= 0 && this.isWordChar(text.charAt(pos))) {
-                pos--;
-            }
-            return pos + 1;
-        },
-
-        findWordEnd: function (text, offset) {
-            offset = Math.max(0, Math.min(offset, text.length - 1));
-            let pos = offset;
-            // Ensure starting within a word if possible
-            if (!this.isWordChar(text.charAt(pos)) && pos > 0 && this.isWordChar(text.charAt(pos - 1))) {
-                pos = pos - 1; // Step back if we landed just after a word
-            }
-            // Move forward from a potential word character
-            while (pos < text.length && this.isWordChar(text.charAt(pos))) {
-                pos++;
-            }
-            return pos;
-        },
-
-        isWordChar: function (char) {
-            // Include Latin characters with macrons
-            return /[a-zA-ZāēīōūĀĒĪŌŪ]/.test(char);
-        },
-
-        isTextNode: function (node) {
-            return node && node.nodeType === Node.TEXT_NODE && node.nodeValue.trim().length > 0;
-        },
-
-        hasTextChild: function (element) { // (Keep hasTextChild as is)
-            if (!element || !element.childNodes) return false;
-            for (let i = 0; i < element.childNodes.length; i++) {
-                const node = element.childNodes[i];
-                if (this.isTextNode(node)) {
-                    return true;
+            
+            // If multiple words, try to find the first Latin word
+            for (const word of words) {
+                const normalized = this.normalizeWord(word);
+                if (this.isLatinWord(normalized)) {
+                    return normalized;
                 }
             }
-            return false;
+            
+            return null;
         },
 
+        /**
+         * Normalize a word by removing punctuation
+         */
+        normalizeWord: function (word) {
+            // Remove trailing punctuation common in text
+            return word.replace(/[.,;:!?)"\]]*$/, '').replace(/^[("\[]*/, '');
+        },
+
+        /**
+         * Check if a word is a valid Latin word
+         */
         isLatinWord: function (word) {
             // Allow macrons, at least 2 letters. Exclude pure numbers.
             return /^[a-zA-ZāēīōūĀĒĪŌŪ]{2,}$/.test(word) && !/^\d+$/.test(word);
         },
 
-        // New function to strip macrons from vowels
+        /**
+         * Strip macrons from vowels for API lookup
+         */
         stripMacrons: function (word) {
             // Replace all macron vowels with their non-macron equivalents
             return word.replace(/[āĀ]/g, 'a')
@@ -674,8 +636,11 @@
                 .replace(/[ūŪ]/g, 'u');
         },
 
+        /**
+         * Look up a word using the Latin API
+         */
         lookupWord: function (word, pageX, pageY, clientX, clientY) {
-            Logger.debug(`Looking up word: ${word} at doc(${pageX}, ${pageY}), view(${clientX}, ${clientY})`);
+            Logger.debug(`Looking up selected word: ${word} at doc(${pageX}, ${pageY}), view(${clientX}, ${clientY})`);
 
             // Store the original word with macrons for display
             const originalWord = word;
@@ -694,27 +659,20 @@
 
             LatinAPI.lookupWord(lookupWord)
                 .then(response => {
-                    if (originalWord === this.lastWord) {
+                    if (originalWord === this.lastSelectedWord) {
                         const parsedData = ResponseParser.parse(response);
                         this.cache[lookupWord] = parsedData;
                         UI.showTooltip(pageX, pageY, clientX, clientY, UI.formatWordInfo(parsedData));
                     } else {
-                        Logger.debug(`Word changed before API response for "${lookupWord}" arrived.`);
+                        Logger.debug(`Selected word changed before API response for "${lookupWord}" arrived.`);
                     }
                 })
                 .catch(error => {
                     Logger.error(`Failed to lookup word "${lookupWord}": ${error}`);
-                    if (originalWord === this.lastWord) {
+                    if (originalWord === this.lastSelectedWord) {
                         UI.showTooltip(pageX, pageY, clientX, clientY, '<div class="latin-lookup-error">Failed to lookup word</div>');
                     }
                 });
-        },
-
-        clearHoverTimer: function () {
-            if (this.hoverTimer) {
-                clearTimeout(this.hoverTimer);
-                this.hoverTimer = null;
-            }
         }
     };
 
@@ -735,7 +693,7 @@
                 color: #333;
                 transition: opacity 0.2s ease-in-out;
                 border-left: 4px solid #5a67d8;
-                pointer-events: none;
+                pointer-events: auto; /* Allow interaction with tooltip for selection-based lookup */
             }
 
             #latin-lookup-toggle { /* (Keep toggle styles as is) */

--- a/auto-lookup-latin-word.user.js
+++ b/auto-lookup-latin-word.user.js
@@ -499,7 +499,6 @@
         setupEventListeners: function () {
             document.addEventListener('mouseup', this.handleTextSelection.bind(this));
             document.addEventListener('keyup', this.handleTextSelection.bind(this));
-            document.addEventListener('selectionchange', this.handleSelectionChange.bind(this));
             
             // Hide tooltip when clicking elsewhere
             document.addEventListener('click', (event) => {
@@ -527,17 +526,6 @@
 
             setTimeout(() => {
                 this.processSelection(event);
-            }, 10); // Small delay to ensure selection is finalized
-        },
-
-        /**
-         * Handle selection change events
-         */
-        handleSelectionChange: function () {
-            if (!UI.enabled) return;
-            
-            setTimeout(() => {
-                this.processSelection();
             }, 10); // Small delay to ensure selection is finalized
         },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lookup of Latin words now activates when you select text, rather than on hover.
  - Tooltip appears near the selected word, allowing direct interaction.

- **Improvements**
  - Updated toggle button tooltip to reflect selection-based lookup.
  - Tooltip is now interactive, supporting pointer events.
  - Tooltip hides when clicking outside if no text is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->